### PR TITLE
로그인 및 회원가입 리펙토링

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/member/controller/MemberController.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/member/controller/MemberController.java
@@ -1,8 +1,8 @@
 package com.cozybinarybase.accountstopthestore.model.member.controller;
 
-import com.cozybinarybase.accountstopthestore.model.member.dto.MemberResponse;
-import com.cozybinarybase.accountstopthestore.model.member.dto.MemberSignInRequest;
-import com.cozybinarybase.accountstopthestore.model.member.dto.MemberSignUpRequest;
+import com.cozybinarybase.accountstopthestore.model.member.dto.MemberResponseDto;
+import com.cozybinarybase.accountstopthestore.model.member.dto.MemberSignInRequestDto;
+import com.cozybinarybase.accountstopthestore.model.member.dto.MemberSignUpRequestDto;
 import com.cozybinarybase.accountstopthestore.model.member.service.MemberService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,17 +19,15 @@ public class MemberController {
 
   private final MemberService memberService;
 
-  // 회원 가입
   @PostMapping("/sign-up")
-  public ResponseEntity<?> signUp(@RequestBody @Valid MemberSignUpRequest memberSignUpRequest) {
-    MemberResponse result = this.memberService.signUp(memberSignUpRequest);
+  public ResponseEntity<?> signUp(@RequestBody @Valid MemberSignUpRequestDto memberSignUpRequest) {
+    MemberResponseDto result = this.memberService.signUp(memberSignUpRequest);
     return ResponseEntity.ok(result);
   }
 
-  // 자체 로그인
   @PostMapping("/sign-in")
-  public ResponseEntity<?> signIn(@RequestBody @Valid MemberSignInRequest memberSignInRequest) {
-    this.memberService.signIn(memberSignInRequest);
+  public ResponseEntity<?> signIn(@RequestBody @Valid MemberSignInRequestDto memberSignInRequestDto) {
+    this.memberService.signIn(memberSignInRequestDto);
     return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/member/domain/Member.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/member/domain/Member.java
@@ -1,6 +1,6 @@
 package com.cozybinarybase.accountstopthestore.model.member.domain;
 
-import com.cozybinarybase.accountstopthestore.model.member.dto.MemberSignUpRequest;
+import com.cozybinarybase.accountstopthestore.model.member.dto.MemberSignUpRequestDto;
 import com.cozybinarybase.accountstopthestore.model.member.dto.constants.AuthType;
 import com.cozybinarybase.accountstopthestore.model.member.dto.constants.Authority;
 import com.cozybinarybase.accountstopthestore.model.member.persist.entity.MemberEntity;
@@ -47,7 +47,7 @@ public class Member implements UserDetails {
 
   private LocalDateTime withdrawalAt;
 
-  public static Member fromSignUpDto(MemberSignUpRequest memberSignUpRequest) {
+  public static Member fromSignUpDto(MemberSignUpRequestDto memberSignUpRequest) {
     return Member.builder()
         .authType(AuthType.EMAIL)
         .email(memberSignUpRequest.getEmail())
@@ -75,7 +75,6 @@ public class Member implements UserDetails {
     this.role = Authority.USER;
   }
 
-  // 비밀번호 암호화 메소드
   public void passwordEncode(PasswordEncoder passwordEncoder) {
     this.password = passwordEncoder.encode(this.password);
   }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/member/dto/MemberResponseDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class MemberResponse {
+public class MemberResponseDto {
 
   private AuthType authType;
 
@@ -19,8 +19,8 @@ public class MemberResponse {
 
   private String email;
 
-  public static MemberResponse fromEntity(MemberEntity memberEntity) {
-    return MemberResponse.builder()
+  public static MemberResponseDto fromEntity(MemberEntity memberEntity) {
+    return MemberResponseDto.builder()
         .authType(memberEntity.getAuthType())
         .name(memberEntity.getName())
         .email(memberEntity.getEmail())

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/member/dto/MemberSignInRequestDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/member/dto/MemberSignInRequestDto.java
@@ -1,17 +1,13 @@
 package com.cozybinarybase.accountstopthestore.model.member.dto;
 
 import javax.validation.constraints.Email;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class MemberSignUpRequest {
-
-  @NotBlank(message = "이름을 입력해주세요.")
-  private String name;
+public class MemberSignInRequestDto {
 
   @Email(message = "이메일 형식이 아닙니다.")
   private String email;

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/member/dto/MemberSignUpRequestDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/member/dto/MemberSignUpRequestDto.java
@@ -1,13 +1,17 @@
 package com.cozybinarybase.accountstopthestore.model.member.dto;
 
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class MemberSignInRequest {
+public class MemberSignUpRequestDto {
+
+  @NotBlank(message = "이름을 입력해주세요.")
+  private String name;
 
   @Email(message = "이메일 형식이 아닙니다.")
   private String email;

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/member/service/MemberService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/member/service/MemberService.java
@@ -3,9 +3,9 @@ package com.cozybinarybase.accountstopthestore.model.member.service;
 import com.cozybinarybase.accountstopthestore.common.handler.exception.MemberMismatchException;
 import com.cozybinarybase.accountstopthestore.common.handler.exception.MemberNotFoundException;
 import com.cozybinarybase.accountstopthestore.model.member.domain.Member;
-import com.cozybinarybase.accountstopthestore.model.member.dto.MemberResponse;
-import com.cozybinarybase.accountstopthestore.model.member.dto.MemberSignInRequest;
-import com.cozybinarybase.accountstopthestore.model.member.dto.MemberSignUpRequest;
+import com.cozybinarybase.accountstopthestore.model.member.dto.MemberResponseDto;
+import com.cozybinarybase.accountstopthestore.model.member.dto.MemberSignInRequestDto;
+import com.cozybinarybase.accountstopthestore.model.member.dto.MemberSignUpRequestDto;
 import com.cozybinarybase.accountstopthestore.model.member.persist.entity.MemberEntity;
 import com.cozybinarybase.accountstopthestore.model.member.persist.repository.MemberRepository;
 import com.cozybinarybase.accountstopthestore.security.TokenProvider;
@@ -35,7 +35,7 @@ public class MemberService implements UserDetailsService {
     return this.memberRepository.findByEmail(email)
         .map(Member::fromEntity)
         .map(member -> {
-          if (member.getPassword() == null){
+          if (member.getPassword() == null) {
             member.setPassword("123456789");
           }
           return member;
@@ -43,7 +43,7 @@ public class MemberService implements UserDetailsService {
         .orElseThrow(() -> new UsernameNotFoundException("가입된 이메일이 아닙니다. -> " + email));
   }
 
-  public MemberResponse signUp(MemberSignUpRequest memberSignUpRequest) {
+  public MemberResponseDto signUp(MemberSignUpRequestDto memberSignUpRequest) {
 
     this.memberRepository.findByEmail(memberSignUpRequest.getEmail()).ifPresent(member -> {
       throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
@@ -53,12 +53,12 @@ public class MemberService implements UserDetailsService {
     member.passwordEncode(this.passwordEncoder);
     MemberEntity memberEntity = this.memberRepository.save(member.toEntity());
 
-    return MemberResponse.fromEntity(memberEntity);
+    return MemberResponseDto.fromEntity(memberEntity);
   }
 
-  public void signIn(MemberSignInRequest memberSignInRequest) {
-    Member member = (Member) this.loadUserByUsername(memberSignInRequest.getEmail());
-    if (!this.passwordEncoder.matches(memberSignInRequest.getPassword(), member.getPassword())) {
+  public void signIn(MemberSignInRequestDto memberSignInRequestDto) {
+    Member member = (Member) this.loadUserByUsername(memberSignInRequestDto.getEmail());
+    if (!this.passwordEncoder.matches(memberSignInRequestDto.getPassword(), member.getPassword())) {
       throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
     }
 

--- a/src/main/java/com/cozybinarybase/accountstopthestore/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/security/JwtAuthenticationFilter.java
@@ -37,19 +37,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     if (refreshToken != null) {
       checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
-      return; // RefreshToken을 보낸 경우에는 AccessToken을 재발급 하고 인증 처리는 하지 않게 하기위해 바로 return으로 필터 진행 막기
+      return;
     }
 
-    String accessToken = this.tokenProvider.extractAccessToken(request)
+    this.tokenProvider.extractAccessToken(request)
         .filter(tokenProvider::validateToken)
-        .orElse(null);
-
-    if (accessToken != null && tokenProvider.validateToken(accessToken)) {
-      Authentication auth = getAuthentication(accessToken);
-      SecurityContextHolder.getContext().setAuthentication(auth);
-
-      log.info(String.format("[%s] -> %s", this.tokenProvider.getUsername(accessToken), request.getRequestURI()));
-    }
+        .ifPresent(accessToken -> {
+          Authentication auth = getAuthentication(accessToken);
+          SecurityContextHolder.getContext().setAuthentication(auth);
+        });
 
     filterChain.doFilter(request, response);
   }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/security/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/security/oauth2/CustomOAuth2User.java
@@ -1,5 +1,8 @@
 package com.cozybinarybase.accountstopthestore.security.oauth2;
 
+import com.cozybinarybase.accountstopthestore.model.member.dto.constants.AuthType;
+import com.cozybinarybase.accountstopthestore.model.member.dto.constants.Authority;
+import com.cozybinarybase.accountstopthestore.model.member.persist.entity.MemberEntity;
 import java.util.Collection;
 import java.util.Map;
 import lombok.Getter;
@@ -22,5 +25,14 @@ public class CustomOAuth2User extends DefaultOAuth2User {
       String nameAttributeKey) {
     super(authorities, attributes, nameAttributeKey);
     this.email = (String) attributes.get("email");
+  }
+
+  public MemberEntity toEntity() {
+    return MemberEntity.builder()
+        .authType(AuthType.GOOGLE)
+        .name((String) getAttributes().get("name"))
+        .email((String) getAttributes().get("email"))
+        .role(Authority.USER)
+        .build();
   }
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/security/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/security/oauth2/OAuth2LoginSuccessHandler.java
@@ -26,11 +26,11 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     this.tokenProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
   }
 
-  private void loginSuccess(HttpServletResponse response, CustomOAuth2User customOAuth2User) throws IOException {
-    String accessToken = tokenProvider.generateAccessToken(customOAuth2User);
-    String refreshToken = tokenProvider.generateRefreshToken();
-
-    tokenProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
-    tokenProvider.updateRefreshToken(customOAuth2User.getEmail(), refreshToken);
-  }
+//  private void loginSuccess(HttpServletResponse response, CustomOAuth2User customOAuth2User) throws IOException {
+//    String accessToken = tokenProvider.generateAccessToken(customOAuth2User);
+//    String refreshToken = tokenProvider.generateRefreshToken();
+//
+//    tokenProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+//    tokenProvider.updateRefreshToken(customOAuth2User.getEmail(), refreshToken);
+//  }
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/security/oauth2/OAuth2Service.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/security/oauth2/OAuth2Service.java
@@ -1,6 +1,5 @@
 package com.cozybinarybase.accountstopthestore.security.oauth2;
 
-import com.cozybinarybase.accountstopthestore.model.member.dto.constants.AuthType;
 import com.cozybinarybase.accountstopthestore.model.member.dto.constants.Authority;
 import com.cozybinarybase.accountstopthestore.model.member.persist.entity.MemberEntity;
 import com.cozybinarybase.accountstopthestore.model.member.persist.repository.MemberRepository;
@@ -34,21 +33,17 @@ public class OAuth2Service implements OAuth2UserService<OAuth2UserRequest, OAuth
 
     String email = (String) attributes.get("email");
 
-    MemberEntity member = memberRepository.findByEmail(email)
-        .orElseGet(() -> memberRepository.save(
-            MemberEntity.builder()
-                .authType(AuthType.GOOGLE)
-                .name((String) attributes.get("name"))
-                .email(email)
-                .role(Authority.USER)
-                .build()
-        ));
-
-    return new CustomOAuth2User(
-        Collections.singleton(new SimpleGrantedAuthority(member.getRole().name())),
+    CustomOAuth2User customOAuth2User = new CustomOAuth2User(
+        Collections.singleton(new SimpleGrantedAuthority(Authority.USER.name())),
         attributes,
         userNameAttributeName
     );
+
+    MemberEntity member = memberRepository.findByEmail(email)
+        .orElseGet(() -> memberRepository.save(
+            customOAuth2User.toEntity()
+        ));
+
+    return customOAuth2User;
   }
 }
-


### PR DESCRIPTION
1. JwtAuthenticationFilter의 doFilterInternal 함수에서 불필요한 validation 제거 후 stream 사용
2. OAuth2Service의 loadUser 안에 구현 된 멤버를 저장하는 로직을 CustomOAuth2User 클래스의 toEntity 함수로 빼냈음.
3. TokenProvider의 JwtParser의 인스턴스를 계속 생성하기 때문에, 싱글톤 패턴을 통해 한번만 생성 되도록 수정함.