### PR TITLE
가계부 조회 수정. cors 설정.

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/config/WebConfig.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/config/WebConfig.java
@@ -1,0 +1,27 @@
+package com.cozybinarybase.accountstopthestore.config;
+
+import com.cozybinarybase.accountstopthestore.model.accountbook.dto.constants.converter.StringToTransactionTypeConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addFormatters(FormatterRegistry registry) {
+    registry.addConverter(new StringToTransactionTypeConverter());
+  }
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**")
+        .allowedOriginPatterns("*") // 모든 도메인 허용
+        .allowedMethods("GET", "POST", "PUT", "DELETE")
+        .allowedHeaders("Authorization", "Content-Type")
+        .exposedHeaders("Custom-Header")
+        .allowCredentials(true)
+        .maxAge(3600);
+  }
+}

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/controller/AccountBookController.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/controller/AccountBookController.java
@@ -74,15 +74,15 @@ public class AccountBookController {
 
   @GetMapping
   public ResponseEntity<?> getAccountBooks(
-      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDateTime,
-      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDateTime,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
       @RequestParam TransactionType transactionType,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "20") int limit,
       @AuthenticationPrincipal Member member) {
-
     List<AccountBookResponseDto> accountBookResponseDtoList =
-        accountBookService.getAccountBooks(startDateTime, endDateTime, transactionType, page, limit, member);
+        accountBookService.getAccountBooks(startDate, endDate, transactionType, page, limit,
+            member);
 
     return ResponseEntity.ok().body(accountBookResponseDtoList);
   }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/AccountBookSaveRequestDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/AccountBookSaveRequestDto.java
@@ -37,5 +37,7 @@ public class AccountBookSaveRequestDto {
   private String address;
   private String memo;
   private RecurringType recurringType;
+
+  @NotNull(message = "정기결제(할부) 여부를 입력해주시길 바랍니다.")
   private Boolean isInstallment;
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/constants/TransactionType.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/constants/TransactionType.java
@@ -1,5 +1,6 @@
 package com.cozybinarybase.accountstopthestore.model.accountbook.dto.constants;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -17,4 +18,3 @@ public enum TransactionType {
     return this.value;
   }
 }
-

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/constants/converter/StringToTransactionTypeConverter.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/constants/converter/StringToTransactionTypeConverter.java
@@ -1,0 +1,18 @@
+package com.cozybinarybase.accountstopthestore.model.accountbook.dto.constants.converter;
+
+import com.cozybinarybase.accountstopthestore.model.accountbook.dto.constants.TransactionType;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToTransactionTypeConverter implements Converter<String, TransactionType> {
+  @Override
+  public TransactionType convert(String source) {
+    for (TransactionType transactionType : TransactionType.values()) {
+      if (transactionType.toValue().equals(source)) {
+        return transactionType;
+      }
+    }
+    throw new IllegalArgumentException("존재하지 않는 Enum 입니다: " + source);
+  }
+}

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/persist/repository/AccountBookRepository.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/persist/repository/AccountBookRepository.java
@@ -19,7 +19,7 @@ public interface AccountBookRepository extends JpaRepository<AccountBookEntity, 
 
   Optional<AccountBookEntity> findByIdAndMember_Id(Long accountBookId, Long memberId);
 
-  Page<AccountBookEntity> findByCreatedAtBetweenAndTransactionTypeAndMember_Id(
+  Page<AccountBookEntity> findByTransactedAtBetweenAndTransactionTypeAndMember_Id(
       LocalDateTime startDate, LocalDateTime endDate, TransactionType transactionType,
       Long memberId, Pageable pageable);
 

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/service/AccountBookService.java
@@ -132,23 +132,20 @@ public class AccountBookService {
   }
 
   @Transactional(readOnly = true)
-  public List<AccountBookResponseDto> getAccountBooks(LocalDateTime startDateTime, LocalDateTime endDateTime,
+  public List<AccountBookResponseDto> getAccountBooks(LocalDate startDate, LocalDate endDate,
       TransactionType transactionType, int page, int limit, Member member) {
     memberService.validateAndGetMember(member);
 
-    startDateTime = startDateTime.toLocalDate().atStartOfDay();
-    endDateTime = endDateTime.toLocalDate().atTime(LocalTime.MAX);
-
-    if (startDateTime.isAfter(endDateTime)) {
+    if (startDate.isAfter(endDate) || endDate.isBefore(startDate)) {
       throw new AccountBookNotValidException("날짜 설정을 다시 해주시길 바랍니다.");
     }
 
     Pageable pageable = PageRequest.of(page, limit);
 
     List<AccountBookEntity> accountBookEntityList =
-        accountBookRepository.findByCreatedAtBetweenAndTransactionTypeAndMember_Id(
-            startDateTime,
-            endDateTime,
+        accountBookRepository.findByTransactedAtBetweenAndTransactionTypeAndMember_Id(
+            startDate.atStartOfDay(),
+            endDate.plusDays(1).atStartOfDay(),
             transactionType,
             member.getId(),
             pageable).getContent();


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 가계부 LocalDateTime 파라미터로 변경했다가 LocalDate로 원복했습니다.
- 가계부 리스트 가져올때 createdAt 대신 transactedAt 기준으로 가져오도록 변경했습니다.
- endDate가 명일의 0시를 가르키도록 변경했습니다.
- TransactionType의 컨버터를 추가했습니다.(프론트에서 값(한글)로 전달받음)
- CORS 설정 추가했습니다.

**TO-BE**

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 
