### PR TITLE
회원가입 코드 유효시간 연장, jdbc 유니코드, 타임존 설정.

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/member/persist/entity/VerificationCode.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/member/persist/entity/VerificationCode.java
@@ -9,7 +9,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
-@RedisHash(value = "VerificationCode", timeToLive = 60)
+@RedisHash(value = "VerificationCode", timeToLive = 300)
 @Builder
 @Data
 @AllArgsConstructor

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,7 +16,7 @@ spring:
       ddl-auto: update
     show-sql: true
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST:localhost}:3306/demo
+    url: jdbc:mysql://${MYSQL_HOST:localhost}:3306/demo?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: root
     password: ${MYSQL_PASSWORD:7845120qwe}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 회원가입 코드 유효시간 5분으로 연장했습니다.
- mysql timezone 변경으로 jdbc url도 맞춰서 수정했습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
