### PR TITLE
순환 참조 제거 및 리펙토링

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/controller/ChallengeGroupController.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/controller/ChallengeGroupController.java
@@ -4,6 +4,8 @@ import com.cozybinarybase.accountstopthestore.model.challenge.dto.ChallengeGroup
 import com.cozybinarybase.accountstopthestore.model.challenge.dto.SavingMoneyRequestDto;
 import com.cozybinarybase.accountstopthestore.model.challenge.service.ChallengeGroupService;
 import com.cozybinarybase.accountstopthestore.model.member.domain.Member;
+import com.cozybinarybase.accountstopthestore.model.message.domain.Message;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -58,8 +60,7 @@ public class ChallengeGroupController {
 
   @PostMapping("/join/{inviteLink}")
   public ResponseEntity<?> joinGroup(@PathVariable String inviteLink, @AuthenticationPrincipal Member member) {
-    challengeGroupService.joinChallengeGroup(inviteLink, member);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.ok(challengeGroupService.joinChallengeGroup(inviteLink, member));
   }
 
   // 서버 추방 & 나가기
@@ -70,4 +71,9 @@ public class ChallengeGroupController {
     return ResponseEntity.ok().build();
   }
 
+  @GetMapping("/{groupId}/messages")
+  public ResponseEntity<?> getMessages(@PathVariable Long groupId, @AuthenticationPrincipal Member member) {
+    List<Message> messages = challengeGroupService.getMessages(groupId, member);
+    return ResponseEntity.ok(messages);
+  }
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/domain/ChallengeGroup.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/domain/ChallengeGroup.java
@@ -61,9 +61,8 @@ public class ChallengeGroup {
         .build();
   }
 
-  //링크 만료 되면 true
-  public boolean isLinkExpired() {
-    return linkExpiredAt.isBefore(LocalDateTime.now());
+  public boolean isLinkValid() {
+    return inviteLink != null && linkExpiredAt.isAfter(LocalDateTime.now());
   }
 
   public ChallengeGroupEntity toEntity() {

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/message/config/WebSocketConfig.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/message/config/WebSocketConfig.java
@@ -24,12 +24,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     registry.addEndpoint("/ws")
-        .setAllowedOriginPatterns("*");
-//        .withSockJS();
+        .setAllowedOriginPatterns("*")
+        .withSockJS();
   }
 
   @Override
   public void configureClientInboundChannel(ChannelRegistration registration) {
-//    registration.interceptors(stompHandler);
+    registration.interceptors(stompHandler);
   }
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/message/controller/MessageController.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/message/controller/MessageController.java
@@ -1,16 +1,10 @@
 package com.cozybinarybase.accountstopthestore.model.message.controller;
 
-import com.cozybinarybase.accountstopthestore.model.member.domain.Member;
 import com.cozybinarybase.accountstopthestore.model.message.domain.Message;
 import com.cozybinarybase.accountstopthestore.model.message.service.MessageService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,12 +17,5 @@ public class MessageController {
   @MessageMapping("/send")
   public void chat(Message message) {
     messageService.saveAndSend(message);
-  }
-
-  //메세지 조회
-  @GetMapping("/group/{groupId}/messages")
-  public ResponseEntity<?> getMessages(@PathVariable Long groupId, @AuthenticationPrincipal Member member) {
-    List<Message> messages = messageService.getMessages(groupId, member);
-    return ResponseEntity.ok(messages);
   }
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/message/service/MessageService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/message/service/MessageService.java
@@ -1,15 +1,7 @@
 package com.cozybinarybase.accountstopthestore.model.message.service;
 
-import com.cozybinarybase.accountstopthestore.model.challenge.domain.ChallengeGroup;
-import com.cozybinarybase.accountstopthestore.model.challenge.persist.entity.ChallengeGroupEntity;
-import com.cozybinarybase.accountstopthestore.model.challenge.persist.repository.ChallengeGroupRepository;
-import com.cozybinarybase.accountstopthestore.model.challenge.persist.repository.MemberGroupRepository;
-import com.cozybinarybase.accountstopthestore.model.challenge.service.ChallengeGroupService;
-import com.cozybinarybase.accountstopthestore.model.member.domain.Member;
 import com.cozybinarybase.accountstopthestore.model.message.domain.Message;
-import com.cozybinarybase.accountstopthestore.model.message.persist.entity.MessageEntity;
 import com.cozybinarybase.accountstopthestore.model.message.persist.repository.MessageRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -19,24 +11,10 @@ import org.springframework.stereotype.Service;
 public class MessageService {
 
   private final MessageRepository messageRepository;
-  private final MemberGroupRepository memberGroupRepository;
-  private final ChallengeGroupRepository challengeGroupRepository;
   private final SimpMessagingTemplate messagingTemplate;
-  private final ChallengeGroupService challengeGroupService;
 
   public void saveAndSend(Message message) {
     messageRepository.save(message.toEntity());
     messagingTemplate.convertAndSend("/chat/group/" + message.getGroupId(), message);
-  }
-
-  public List<Message> getMessages(Long groupId, Member member) {
-    ChallengeGroupEntity challengeGroupEntity = challengeGroupRepository.findById(groupId)
-        .orElseThrow(() -> new IllegalArgumentException("그룹이 존재하지 않습니다."));
-
-    if (!challengeGroupService.isChallengeGroupMember(ChallengeGroup.fromEntity(challengeGroupEntity), member)) {
-      throw new IllegalArgumentException("그룹에 속해 있지 않습니다.");
-    }
-    List<MessageEntity> messageEntities = messageRepository.findByGroup(challengeGroupEntity);
-    return Message.fromEntities(messageEntities);
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- MessageService와 ChallengeGroupService가 서로 순환 참조 했다.
- 불필요한 코드 존재
**TO-BE**
- 메세지 조회 api 엔드 포인트 변경
- 메세지 조회 api 위치 MessageController에서 ChallengeController로 위치 변경
- 이에 따른 getMessage 함수 MessageService에서 ChallengeGroupService로 위치 변경
- challengeGroup.getInviteLink() != null && !challengeGroup.isLinkExpired()의 로직을 ChallengeGroup 도메인 내부에 isLinkValid로 구현
- getChallengeGroups 함수 내부에 중복 되던 로직 삭제
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
