### PR TITLE
리프레시 토큰 저장, 발급, 재설정 로직 수정.

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/member/domain/Member.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/member/domain/Member.java
@@ -85,6 +85,7 @@ public class Member implements UserDetails {
 
   public MemberEntity toEntity() {
     return MemberEntity.builder()
+        .id(this.id)
         .authType(this.authType)
         .oauthId(this.oauthId)
         .refreshToken(this.refreshToken)

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/member/service/MemberService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/member/service/MemberService.java
@@ -127,6 +127,12 @@ public class MemberService implements UserDetailsService {
     String accessToken = this.tokenProvider.generateAccessToken(member);
     String refreshToken = this.tokenProvider.generateRefreshToken();
 
+    memberRepository.findByEmail(member.getEmail())
+            .ifPresent(memberEntity -> {
+              memberEntity.setRefreshToken(refreshToken);
+              memberRepository.save(memberEntity);
+            });
+
     tokenProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
   }
 

--- a/src/main/java/com/cozybinarybase/accountstopthestore/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/security/JwtAuthenticationFilter.java
@@ -2,10 +2,12 @@ package com.cozybinarybase.accountstopthestore.security;
 
 
 import com.cozybinarybase.accountstopthestore.model.member.domain.Member;
+import com.cozybinarybase.accountstopthestore.model.member.persist.entity.MemberEntity;
 import com.cozybinarybase.accountstopthestore.model.member.persist.repository.MemberRepository;
 import com.cozybinarybase.accountstopthestore.model.member.service.MemberService;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -46,10 +48,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
           .orElse(null);
 
       if (refreshToken != null) {
-        checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
-
-        String newAccessToken = this.tokenProvider.extractAccessToken(request).orElse(null);
-        if (newAccessToken != null) {
+        refreshToken = checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
+        Optional<MemberEntity> memberEntityOpt = memberRepository.findByRefreshToken(refreshToken);
+        if (memberEntityOpt.isPresent()) {
+          Member member = Member.fromEntity(memberEntityOpt.get());
+          String newAccessToken = this.tokenProvider.generateAccessToken(member);
           Authentication newAuth = getAuthentication(newAccessToken);
           SecurityContextHolder.getContext().setAuthentication(newAuth);
         }
@@ -67,14 +70,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
   }
 
-  public void checkRefreshTokenAndReIssueAccessToken(HttpServletResponse response, String refreshToken) {
+  public String checkRefreshTokenAndReIssueAccessToken(HttpServletResponse response, String refreshToken) {
+    AtomicReference<String> newRefreshTokenRef = new AtomicReference<>();
+
     memberRepository.findByRefreshToken(refreshToken)
         .ifPresent(memberEntity -> {
           Member member = Member.fromEntity(memberEntity);
           String reIssuedRefreshToken = reIssueRefreshToken(member);
           tokenProvider.sendAccessAndRefreshToken(response, tokenProvider.generateAccessToken(member),
               reIssuedRefreshToken);
+          newRefreshTokenRef.set(reIssuedRefreshToken);
         });
+
+    return newRefreshTokenRef.get();
   }
 
   private String reIssueRefreshToken(Member member) {


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 액세스 토큰 만료시 리프레시 토큰을 저장, 발급, 재설정하는 부분에 문제가 있어 수정했습니다.

**TO-BE**

### 테스트
- [ ] 테스트 코드
- [ ] API 테스트 
