### PR TITLE
기록지 기능 작성, 멤버 엔터티 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.3'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-  implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.json:json:20231013'
 	implementation 'commons-io:commons-io:2.15.0'
 
 	// querydsl

--- a/src/main/java/com/cozybinarybase/accountstopthestore/common/service/AddressService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/common/service/AddressService.java
@@ -1,0 +1,49 @@
+package com.cozybinarybase.accountstopthestore.common.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.json.JSONObject;
+
+@Service
+@RequiredArgsConstructor
+public class AddressService {
+
+  @Value("${kakao.api.key}")
+  private String apiKey;
+
+  private final RestTemplate restTemplate;
+
+  public JSONObject getAddressInfo(String address) {
+    final String url = "https://dapi.kakao.com/v2/local/search/address.json?query=" + address;
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "KakaoAK " + apiKey);
+
+    HttpEntity<String> entity = new HttpEntity<>(headers);
+
+    ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+
+    return new JSONObject(response.getBody());
+  }
+
+  public Map<String, String> getCoordinates(String address) {
+    JSONObject addressInfoJson = getAddressInfo(address);
+    Map<String, String> coordinates = new HashMap<>();
+
+    if (!addressInfoJson.getJSONArray("documents").isEmpty()) {
+      JSONObject documentObject = addressInfoJson.getJSONArray("documents").getJSONObject(0);
+      coordinates.put("x", documentObject.getString("x"));
+      coordinates.put("y", documentObject.getString("y"));
+    }
+
+    return coordinates;
+  }
+}

--- a/src/main/java/com/cozybinarybase/accountstopthestore/config/AppConfig.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/config/AppConfig.java
@@ -1,9 +1,15 @@
 package com.cozybinarybase.accountstopthestore.config;
 
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class AppConfig {
@@ -11,5 +17,10 @@ public class AppConfig {
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
   }
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/controller/AccountBookController.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/controller/AccountBookController.java
@@ -11,7 +11,6 @@ import com.cozybinarybase.accountstopthestore.model.accountbook.dto.constants.Tr
 import com.cozybinarybase.accountstopthestore.model.accountbook.service.AccountBookService;
 import com.cozybinarybase.accountstopthestore.model.member.domain.Member;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -132,5 +131,15 @@ public class AccountBookController {
       @AuthenticationPrincipal Member member) {
     return ResponseEntity.ok().body(accountBookService.getTransactionStatistics(
         startDate, endDate, transactionType, member));
+  }
+
+  @GetMapping("/nearby")
+  public ResponseEntity<List<AccountBookResponseDto>> getNearbyAccountBooks(@RequestParam double lat,
+      @RequestParam double lng,
+      @AuthenticationPrincipal Member member) {
+    double radius = 100.0;
+    List<AccountBookResponseDto> nearbyAccountBooks = accountBookService
+        .findAccountBooksNearby(lat, lng, radius, member);
+    return ResponseEntity.ok(nearbyAccountBooks);
   }
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/AccountBookResponseDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/AccountBookResponseDto.java
@@ -40,6 +40,9 @@ public class AccountBookResponseDto {
   @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
   private LocalDateTime updatedAt;
 
+  double latitude;
+  double longitude;
+
   public static AccountBookResponseDto fromEntity(AccountBookEntity accountBookEntity) {
     List<Long> imageIdList = accountBookEntity.getImages().stream()
         .map(ImageEntity::getImageId)
@@ -59,6 +62,8 @@ public class AccountBookResponseDto {
         .isInstallment(accountBookEntity.getIsInstallment())
         .createdAt(accountBookEntity.getCreatedAt())
         .updatedAt(accountBookEntity.getUpdatedAt())
+        .latitude(accountBookEntity.getLatitude())
+        .longitude(accountBookEntity.getLongitude())
         .build();
   }
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/persist/entity/AccountBookEntity.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/persist/entity/AccountBookEntity.java
@@ -78,6 +78,12 @@ public class AccountBookEntity {
   @Column(name = "updatedAt", nullable = false)
   private LocalDateTime updatedAt;
 
+  @Column(name = "latitude")
+  private Double latitude;
+
+  @Column(name = "longitude")
+  private Double longitude;
+
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "categoryId")
   private CategoryEntity category;

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/persist/repository/AccountBookRepository.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/persist/repository/AccountBookRepository.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AccountBookRepository extends JpaRepository<AccountBookEntity, Long>,
     AccountBookRepositoryCustom {
@@ -50,4 +52,12 @@ public interface AccountBookRepository extends JpaRepository<AccountBookEntity, 
     // 결과 반환
     return query.fetch();
   }
+
+  @Query(value = "SELECT * FROM account_book WHERE member_id = :memberId AND "
+      + "ST_Distance_Sphere(point(longitude, latitude), point(:longitude, :latitude)) "
+      + "<= :radius", nativeQuery = true)
+  List<AccountBookEntity> findWithinRadius(@Param("latitude") double latitude,
+      @Param("longitude") double longitude,
+      @Param("radius") double radius,
+      @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/member/persist/entity/MemberEntity.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/member/persist/entity/MemberEntity.java
@@ -5,18 +5,26 @@ import com.cozybinarybase.accountstopthestore.BaseTimeEntity;
 import com.cozybinarybase.accountstopthestore.model.member.dto.constants.AuthType;
 import com.cozybinarybase.accountstopthestore.model.member.dto.constants.Authority;
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Entity(name = "member")
+@Entity
+@Table(name = "member", indexes = {
+    @Index(columnList = "oauthId"),
+    @Index(columnList = "email"),
+    @Index(columnList = "refreshToken")
+})
 @Builder
 @Data
 @AllArgsConstructor
@@ -30,12 +38,14 @@ public class MemberEntity extends BaseTimeEntity {
   @Enumerated(EnumType.STRING)
   private AuthType authType;
 
+  @Column(unique = true)
   private String oauthId; // 일반 회원 가입은 null
 
   private String refreshToken;
 
   private String name;
 
+  @Column(unique = true)
   private String email;
 
   private String password;

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -47,3 +47,7 @@ azure:
   ocr:
     endpoint: ${AZURE_OCR_ENDPOINT:azure_ocr_endpoint}
     key: ${AZURE_OCR_KEY:azure_ocr_key}
+
+kakao:
+  api:
+    key: ${KAKAO_API_KEY:kakao_api_key}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 가계부 등록시 카카오 api 사용해서 주소로부터 좌표를 저장하도록 했습니다.
- 위, 경도를 입력하면 주변의 가계부를 반환하는 기능을 작성했습니다.
- 멤버 엔터티에 인덱스 설정(oauthId, email, refreshToken) 및 oauthId와 email에 유니크 설정 추가했습니다.

**TO-BE**

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 
