### PR TITLE
챌린지 그룹 원복 및 월별 가계부 조회 추가.

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/controller/AccountBookController.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/controller/AccountBookController.java
@@ -11,6 +11,7 @@ import com.cozybinarybase.accountstopthestore.model.accountbook.dto.constants.Tr
 import com.cozybinarybase.accountstopthestore.model.accountbook.service.AccountBookService;
 import com.cozybinarybase.accountstopthestore.model.member.domain.Member;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,17 @@ public class AccountBookController {
       @AuthenticationPrincipal Member member) {
     AccountBookResponseDto responseDto = accountBookService.getAccountBook(accountId, member);
     return ResponseEntity.ok().body(responseDto);
+  }
+
+  @GetMapping("/monthly")
+  public ResponseEntity<List<AccountBookResponseDto>> getMonthlyAccountBooks(
+      @RequestParam @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth,
+      @AuthenticationPrincipal Member member) {
+
+    List<AccountBookResponseDto> accountBookResponseDtoList =
+        accountBookService.getMonthlyAccountBooks(yearMonth, member);
+
+    return ResponseEntity.ok(accountBookResponseDtoList);
   }
 
   @PostMapping

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/persist/repository/AccountBookRepository.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/persist/repository/AccountBookRepository.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -60,4 +61,10 @@ public interface AccountBookRepository extends JpaRepository<AccountBookEntity, 
       @Param("longitude") double longitude,
       @Param("radius") double radius,
       @Param("memberId") Long memberId);
+
+  List<AccountBookEntity> findByTransactedAtBetweenAndMember_Id(
+      LocalDateTime startDateTime,
+      LocalDateTime endDateTime,
+      Long memberId
+  );
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/service/AccountBookService.java
@@ -30,6 +30,7 @@ import com.cozybinarybase.accountstopthestore.model.member.service.MemberService
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -183,6 +184,26 @@ public class AccountBookService {
             transactionType,
             member.getId(),
             pageable).getContent();
+
+    return accountBookEntityList.stream()
+        .map(AccountBookResponseDto::fromEntity)
+        .collect(Collectors.toList());
+  }
+
+  @Transactional(readOnly = true)
+  public List<AccountBookResponseDto> getMonthlyAccountBooks(
+      YearMonth yearMonth, Member member) {
+
+    memberService.validateAndGetMember(member);
+
+    LocalDate startDate = yearMonth.atDay(1);
+    LocalDate endDate = yearMonth.atEndOfMonth();
+
+    List<AccountBookEntity> accountBookEntityList =
+        accountBookRepository.findByTransactedAtBetweenAndMember_Id(
+            startDate.atStartOfDay(),
+            endDate.atTime(LocalTime.MAX),
+            member.getId());
 
     return accountBookEntityList.stream()
         .map(AccountBookResponseDto::fromEntity)

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/dto/ChallengeGroupResponseDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/dto/ChallengeGroupResponseDto.java
@@ -2,7 +2,6 @@ package com.cozybinarybase.accountstopthestore.model.challenge.dto;
 
 import com.cozybinarybase.accountstopthestore.model.challenge.persist.entity.ChallengeGroupEntity;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -39,11 +38,5 @@ public class ChallengeGroupResponseDto {
         .endAt(challengeGroupEntity.getEndAt())
         .adminId(challengeGroupEntity.getAdmin().getId())
         .build();
-  }
-
-  public static List<ChallengeGroupResponseDto> fromEntities(List<ChallengeGroupEntity> challengeGroupEntities) {
-    return challengeGroupEntities.stream()
-        .map(ChallengeGroupResponseDto::fromEntity)
-        .toList();
   }
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/persist/repository/ChallengeGroupRepository.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/persist/repository/ChallengeGroupRepository.java
@@ -1,8 +1,6 @@
 package com.cozybinarybase.accountstopthestore.model.challenge.persist.repository;
 
 import com.cozybinarybase.accountstopthestore.model.challenge.persist.entity.ChallengeGroupEntity;
-import com.cozybinarybase.accountstopthestore.model.member.persist.entity.MemberEntity;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,6 +9,4 @@ import org.springframework.stereotype.Repository;
 public interface ChallengeGroupRepository extends JpaRepository<ChallengeGroupEntity, Long> {
 
   Optional<ChallengeGroupEntity> findByInviteLink(String inviteLink);
-
-  List<ChallengeGroupEntity> findByMember(MemberEntity entity);
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/service/ChallengeGroupService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/service/ChallengeGroupService.java
@@ -14,7 +14,6 @@ import com.cozybinarybase.accountstopthestore.model.challenge.security.RandomStr
 import com.cozybinarybase.accountstopthestore.model.member.domain.Member;
 import com.cozybinarybase.accountstopthestore.model.member.persist.entity.MemberEntity;
 import com.cozybinarybase.accountstopthestore.model.member.persist.repository.MemberRepository;
-import com.cozybinarybase.accountstopthestore.model.member.service.MemberService;
 import com.cozybinarybase.accountstopthestore.model.message.domain.Message;
 import com.cozybinarybase.accountstopthestore.model.message.persist.entity.MessageEntity;
 import com.cozybinarybase.accountstopthestore.model.message.persist.repository.MessageRepository;
@@ -30,7 +29,6 @@ public class ChallengeGroupService {
   private final ChallengeGroupRepository challengeGroupRepository;
   private final MemberGroupRepository memberGroupRepository;
   private final MemberRepository memberRepository;
-  private final MemberService memberService;
   private final MessageRepository messageRepository;
   private final MessageService messageService;
 
@@ -118,10 +116,9 @@ public class ChallengeGroupService {
     return memberIds.contains(member.getId());
   }
 
+  //TODO
   public List<ChallengeGroupResponseDto> getChallengeGroups(Member member) {
-    memberService.validateAndGetMember(member);
-    List<ChallengeGroupEntity> challengeGroupEntities = challengeGroupRepository.findByMember(member.toEntity());
-    return ChallengeGroupResponseDto.fromEntities(challengeGroupEntities);
+    return null;
   }
 
   public ChallengeGroupResponseDto updateChallengeGroup(Long groupId, ChallengeGroupRequestDto challengeGroupRequestDto,


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 챌린지 그룹 코드 변경점 원복했습니다.
- 월별로 가계부 조회 기능 추가했습니다.

**TO-BE**

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 
