### PR TITLE
Refactor update

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/controller/ChallengeGroupController.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/controller/ChallengeGroupController.java
@@ -47,7 +47,7 @@ public class ChallengeGroupController {
     return ResponseEntity.ok(challengeGroupService.deleteChallengeGroup(groupId, member));
   }
 
-  @PostMapping("/{groupID}/saving")
+  @PostMapping("/{groupId}/saving")
   public ResponseEntity<?> saveMoney(@PathVariable Long groupId,
       @RequestBody SavingMoneyRequestDto savingMoneyRequestDto, @AuthenticationPrincipal Member member) {
     return ResponseEntity.ok(challengeGroupService.saveMoney(groupId, savingMoneyRequestDto, member));

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/domain/MemberGroup.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/domain/MemberGroup.java
@@ -18,14 +18,18 @@ public class MemberGroup {
 
   private Long id;
   private Long memberId;
+  private String memberName;
   private Long challengeGroupId;
+  private String groupName;
   private Long savedAmount;
 
   public static MemberGroup fromEntity(MemberGroupEntity memberGroupEntity) {
     return MemberGroup.builder()
         .id(memberGroupEntity.getId())
         .memberId(memberGroupEntity.getMember().getId())
+        .memberName(memberGroupEntity.getMember().getName())
         .challengeGroupId(memberGroupEntity.getChallengeGroup().getId())
+        .groupName(memberGroupEntity.getChallengeGroup().getName())
         .savedAmount(memberGroupEntity.getSavedAmount())
         .build();
   }
@@ -33,15 +37,17 @@ public class MemberGroup {
   public static MemberGroup create(ChallengeGroup group, Member member) {
     return MemberGroup.builder()
         .memberId(member.getId())
+        .memberName(member.getName())
         .challengeGroupId(group.getId())
+        .groupName(group.getName())
         .savedAmount(0L)
         .build();
   }
 
   public MemberGroupEntity toEntity() {
     return MemberGroupEntity.builder()
-        .member(MemberEntity.builder().id(memberId).build())
-        .challengeGroup(ChallengeGroupEntity.builder().id(challengeGroupId).build())
+        .member(MemberEntity.builder().id(memberId).name(memberName).build())
+        .challengeGroup(ChallengeGroupEntity.builder().id(challengeGroupId).name(groupName).build())
         .savedAmount(savedAmount)
         .build();
   }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/persist/repository/MemberGroupRepository.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/persist/repository/MemberGroupRepository.java
@@ -19,4 +19,6 @@ public interface MemberGroupRepository extends JpaRepository<MemberGroupEntity, 
       ChallengeGroupEntity challengeGroupEntity);
 
   List<MemberGroupEntity> findByMember(MemberEntity entity);
+
+  Long countByChallengeGroup(ChallengeGroupEntity entity);
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/service/ChallengeGroupService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/service/ChallengeGroupService.java
@@ -74,6 +74,10 @@ public class ChallengeGroupService {
       throw new IllegalArgumentException("이미 그룹에 속해있습니다.");
     }
 
+    if (challengeGroup.getMaxMembers() <= memberGroupRepository.countByChallengeGroup(challengeGroup.toEntity())) {
+      throw new IllegalArgumentException("그룹 인원이 꽉 찼습니다.");
+    }
+
     Message enterMessage = Message.createEnterMessage(challengeGroup, member);
 
     messageService.saveAndSend(enterMessage);

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/message/domain/Message.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/message/domain/Message.java
@@ -6,6 +6,7 @@ import com.cozybinarybase.accountstopthestore.model.member.domain.Member;
 import com.cozybinarybase.accountstopthestore.model.member.persist.entity.MemberEntity;
 import com.cozybinarybase.accountstopthestore.model.message.dto.constants.MessageType;
 import com.cozybinarybase.accountstopthestore.model.message.persist.entity.MessageEntity;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,6 +24,7 @@ public class Message {
   private Long senderId; // 채팅을 보낸 사람
   private String message; // 메시지
   private MessageType messageType;
+  private LocalDateTime createdAt;
 
   public static Message fromEntity(MessageEntity messageEntity) {
     return Message.builder()
@@ -31,6 +33,7 @@ public class Message {
         .senderId(messageEntity.getSender().getId())
         .message(messageEntity.getMessage())
         .messageType(messageEntity.getMessageType())
+        .createdAt(messageEntity.getCreatedAt())
         .build();
   }
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- ChallengeGroupController에 있던 saveMoney메소드 호출하는 URI 오타 수정
- MemberGroup 도메인에서 MemberGroupEntity로 memberName, groupName도 같이 넘겨주도록 수정
- 그룹 입장 시, admin이 설정한 최대 인원과 현재 인원을 비교하는 로직 추가
- Message 도메인에 createdAt(보낸 시간) 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
