### PR TITLE
도메인에서 엔터티로 넘겨줄 때 id도 같이 넘겨주도록 toEntity 메소드 수정

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/domain/ChallengeGroup.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/domain/ChallengeGroup.java
@@ -10,11 +10,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Component
 public class ChallengeGroup {
 
   private Long id;

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/domain/MemberGroup.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/domain/MemberGroup.java
@@ -9,11 +9,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Component
 public class MemberGroup {
 
   private Long id;
@@ -46,6 +48,7 @@ public class MemberGroup {
 
   public MemberGroupEntity toEntity() {
     return MemberGroupEntity.builder()
+        .id(id)
         .member(MemberEntity.builder().id(memberId).name(memberName).build())
         .challengeGroup(ChallengeGroupEntity.builder().id(challengeGroupId).name(groupName).build())
         .savedAmount(savedAmount)

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/persist/entity/MemberGroupEntity.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/persist/entity/MemberGroupEntity.java
@@ -22,7 +22,7 @@ public class MemberGroupEntity extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private long id;
+  private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   private MemberEntity member;

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/service/ChallengeGroupService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/service/ChallengeGroupService.java
@@ -35,6 +35,10 @@ public class ChallengeGroupService {
   private final MessageRepository messageRepository;
   private final MessageService messageService;
 
+  private final ChallengeGroup challengeGroup;
+  private final MemberGroup memberGroup;
+
+
   public InviteLinkResponseDto createInviteLink(Long groupId, Member member) {
     ChallengeGroup challengeGroup = challengeGroupRepository.findById(groupId)
         .map(ChallengeGroup::fromEntity)
@@ -59,9 +63,11 @@ public class ChallengeGroupService {
   public ChallengeGroupResponseDto createChallengeGroup(ChallengeGroupRequestDto challengeGroupRequestDto,
       Member member) {
     ChallengeGroupEntity challengeGroupEntity = challengeGroupRepository.save(
-        ChallengeGroup.fromRequest(challengeGroupRequestDto, member).toEntity());
+        challengeGroup.fromRequest(challengeGroupRequestDto, member).toEntity());
 
-    memberGroupRepository.save(MemberGroup.create(ChallengeGroup.fromEntity(challengeGroupEntity), member).toEntity());
+    memberGroupRepository.save(memberGroup.create(ChallengeGroup.fromEntity(challengeGroupEntity), member)
+        .toEntity());
+
     return ChallengeGroupResponseDto.fromEntity(challengeGroupEntity);
   }
 
@@ -171,9 +177,8 @@ public class ChallengeGroupService {
         .map(MemberGroup::fromEntity)
         .orElseThrow(() -> new IllegalArgumentException("그룹에 속해 있지 않습니다."));
 
-    memberGroupRepository.save(memberGroup.updateSavedAmount(savingMoneyRequestDto).toEntity());
-
-    return MemberGroupResponseDto.fromEntity(memberGroup.toEntity());
+    return MemberGroupResponseDto.fromEntity(
+        memberGroupRepository.save(memberGroup.updateSavedAmount(savingMoneyRequestDto).toEntity()));
   }
 
   public List<Message> getMessages(Long groupId, Member member) {


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- Membergroup 도메인 안의 toEntity() 메소드 id 값도 같이 넘겨주도록 수정
- MembergroupEntity에 id값이 long으로 되어 있던 것을 Long 으로 수정
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
