### PR TITLE
JaCoCo 리포트 생성.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'org.springframework.boot' version '2.7.17'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
+	id 'jacoco'
 }
 
 group = 'com.example'
@@ -10,6 +11,17 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = "16"
+}
+
+jacoco {
+	toolVersion = "0.8.7"
+}
+
+jacocoTestReport {
+	reports {
+		xml.required = true
+		html.required = true
+	}
 }
 
 configurations {


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 'gradle test jacocoTestReport' 명령어를 실행하면 jacoco 테스트 리포트를 생성합니다.
- 생성된 리포트는 다음 경로에서 확인할 수 있습니다. '/build/reports/jacoco/test/html/index.html'

**TO-BE**
- Jenkins CI 과정에 통합.

### 테스트
- [ ] 테스트 코드
- [ ] API 테스트 
