### PR TITLE
도로명 주소 기준으로 좌표를 저장.

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/common/service/AddressService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/common/service/AddressService.java
@@ -40,8 +40,9 @@ public class AddressService {
 
     if (!addressInfoJson.getJSONArray("documents").isEmpty()) {
       JSONObject documentObject = addressInfoJson.getJSONArray("documents").getJSONObject(0);
-      coordinates.put("x", documentObject.getString("x"));
-      coordinates.put("y", documentObject.getString("y"));
+      JSONObject roadAddressObject = documentObject.getJSONObject("road_address");
+      coordinates.put("x", roadAddressObject.getString("x"));
+      coordinates.put("y", roadAddressObject.getString("y"));
     }
 
     return coordinates;


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 카카오 지도 API에서 지번과 도로명 주소에 따라 좌표값이 다르게 나와서 지번으로 입력을 받아도 도로명 기준으로 좌표를 저장하도록 변경했습니다.

**TO-BE**

### 테스트
- [ ] 테스트 코드
- [ ] API 테스트 
