### PR TITLE
그룹 삭제 기능 수정

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/persist/repository/MemberGroupRepository.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/persist/repository/MemberGroupRepository.java
@@ -23,4 +23,6 @@ public interface MemberGroupRepository extends JpaRepository<MemberGroupEntity, 
   Long countByChallengeGroup(ChallengeGroupEntity entity);
 
   void deleteAllByMemberId(Long memberId);
+
+  void deleteByChallengeGroupId(Long groupId);
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/persist/repository/MemberGroupRepository.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/persist/repository/MemberGroupRepository.java
@@ -24,5 +24,5 @@ public interface MemberGroupRepository extends JpaRepository<MemberGroupEntity, 
 
   void deleteAllByMemberId(Long memberId);
 
-  void deleteByChallengeGroupId(Long groupId);
+  void deleteByChallengeGroup(ChallengeGroupEntity challengeGroupEntity);
 }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/service/ChallengeGroupService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/service/ChallengeGroupService.java
@@ -168,6 +168,7 @@ public class ChallengeGroupService {
       throw new IllegalArgumentException("그룹장이 삭제 할 수 있습니다.");
     }
 
+    memberGroupRepository.deleteByChallengeGroupId(groupId);
     challengeGroupRepository.delete(challengeGroup.toEntity());
     return groupId;
   }

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/service/ChallengeGroupService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/challenge/service/ChallengeGroupService.java
@@ -21,6 +21,7 @@ import com.cozybinarybase.accountstopthestore.model.message.persist.entity.Messa
 import com.cozybinarybase.accountstopthestore.model.message.persist.repository.MessageRepository;
 import com.cozybinarybase.accountstopthestore.model.message.service.MessageService;
 import java.util.List;
+import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -159,6 +160,7 @@ public class ChallengeGroupService {
   }
 
   //TODO: 그룹 삭제시 MemberGroup이 기록은 남아있되 사용은 못하도록 하기
+  @Transactional
   public Long deleteChallengeGroup(Long groupId, Member member) {
     ChallengeGroup challengeGroup = challengeGroupRepository.findById(groupId)
         .map(ChallengeGroup::fromEntity)
@@ -168,8 +170,11 @@ public class ChallengeGroupService {
       throw new IllegalArgumentException("그룹장이 삭제 할 수 있습니다.");
     }
 
-    memberGroupRepository.deleteByChallengeGroupId(groupId);
-    challengeGroupRepository.delete(challengeGroup.toEntity());
+    ChallengeGroupEntity challengeGroupEntity = challengeGroup.toEntity();
+
+    messageRepository.deleteAllByGroup(challengeGroupEntity);
+    memberGroupRepository.deleteByChallengeGroup(challengeGroupEntity);
+    challengeGroupRepository.delete(challengeGroupEntity);
     return groupId;
   }
 

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/message/persist/repository/MessageRepository.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/message/persist/repository/MessageRepository.java
@@ -1,5 +1,6 @@
 package com.cozybinarybase.accountstopthestore.model.message.persist.repository;
 
+import com.cozybinarybase.accountstopthestore.model.challenge.domain.ChallengeGroup;
 import com.cozybinarybase.accountstopthestore.model.challenge.persist.entity.ChallengeGroupEntity;
 import com.cozybinarybase.accountstopthestore.model.message.persist.entity.MessageEntity;
 import java.util.List;
@@ -12,4 +13,6 @@ public interface MessageRepository extends JpaRepository<MessageEntity, Long> {
   List<MessageEntity> findByGroup(ChallengeGroupEntity challengeGroupEntity);
 
   void deleteAllBySender(Long memberId);
+
+  void deleteAllByGroup(ChallengeGroupEntity challengeGroupEntity);
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 그룹 삭제시 연관된 채팅메세지, member_group, 그룹 순으로 삭제하도록 변경했습니다.

**TO-BE**

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 
