### PR TITLE
카드사, 은행은 fixed하게, 표시되는 이름은 사용자 지정

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/common/service/AddressService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/common/service/AddressService.java
@@ -40,6 +40,8 @@ public class AddressService {
 
     if (!addressInfoJson.getJSONArray("documents").isEmpty()) {
       JSONObject documentObject = addressInfoJson.getJSONArray("documents").getJSONObject(0);
+      // road_address가 존재하지 않을 경우 예외처리
+      // 커스텀 예외 작성 후 전역 예외 핸들러에서 처리
       JSONObject roadAddressObject = documentObject.getJSONObject("road_address");
       coordinates.put("x", roadAddressObject.getString("x"));
       coordinates.put("y", roadAddressObject.getString("y"));

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/AccountBookResponseDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/AccountBookResponseDto.java
@@ -20,7 +20,9 @@ public class AccountBookResponseDto {
 
   private Long accountId;
   private String categoryName;
+  private String assetGroup;
   private String assetType;
+  private String assetName;
   private Long amount;
   private String transactionType;
   private String transactionDetail;
@@ -52,7 +54,9 @@ public class AccountBookResponseDto {
     return AccountBookResponseDto.builder()
         .accountId(accountBookEntity.getId())
         .categoryName(accountBookEntity.getCategory().getName())
-        .assetType(accountBookEntity.getAsset().getName())
+        .assetGroup(accountBookEntity.getAsset().getGroup().getValue())
+        .assetType(accountBookEntity.getAsset().getType().getValue())
+        .assetName(accountBookEntity.getAsset().getName())
         .amount(accountBookEntity.getAmount())
         .transactionType(accountBookEntity.getTransactionType().getValue())
         .transactionDetail(accountBookEntity.getTransactionDetail())

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/AccountBookSaveResponseDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/AccountBookSaveResponseDto.java
@@ -11,15 +11,19 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Getter
+@Setter
 public class AccountBookSaveResponseDto {
 
   private Long accountId;
   private String categoryName;
+  private String assetGroup;
+  private String assetType;
   private String assetName;
   private Long amount;
   private String transactionType;

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/AccountBookUpdateResponseDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/dto/AccountBookUpdateResponseDto.java
@@ -11,15 +11,19 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Getter
+@Setter
 public class AccountBookUpdateResponseDto {
 
   private Long accountId;
   private String categoryName;
+  private String assetGroup;
+  private String assetType;
   private String assetName;
   private Long amount;
   private String transactionType;
@@ -50,6 +54,7 @@ public class AccountBookUpdateResponseDto {
         .transactionType(accountBookEntity.getTransactionType().getValue())
         .transactionDetail(accountBookEntity.getTransactionDetail())
         .transactedAt(accountBookEntity.getTransactedAt())
+        .address(accountBookEntity.getAddress())
         .memo(accountBookEntity.getMemo())
         .imageIds(imageIdList)
         .isInstallment(accountBookEntity.getIsInstallment())

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/service/AccountBookService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/accountbook/service/AccountBookService.java
@@ -101,8 +101,12 @@ public class AccountBookService {
     // AccountBookEntity 저장
     accountBookEntity = accountBookRepository.save(accountBookEntity);
 
+    AccountBookSaveResponseDto responseDto = AccountBookSaveResponseDto.fromEntity(accountBookEntity);
+    responseDto.setAssetGroup(assetEntity.getGroup().getValue());
+    responseDto.setAssetType(assetEntity.getType().getValue());
+
     // DTO 변환 및 반환
-    return AccountBookSaveResponseDto.fromEntity(accountBookEntity);
+    return responseDto;
   }
 
   @Transactional
@@ -129,11 +133,12 @@ public class AccountBookService {
     AccountBook accountBookDomain = AccountBook.fromEntity(accountBookEntity);
     accountBookDomain.updateAccountBook(requestDto, categoryEntity.getId(), assetEntity.getId(), images);
 
+    accountBookEntity = accountBookDomain.toEntity();
 
-    images.forEach(image -> {
-      image.setAccountBook(accountBookEntity);
-      imageRepository.save(image);
-    });
+    for (ImageEntity img : images) {
+      img.setAccountBook(accountBookEntity);
+      imageRepository.save(img);
+    }
 
     accountBookEntity.setImages(images);
 
@@ -152,7 +157,11 @@ public class AccountBookService {
 
     AccountBookEntity updatedAccountBookEntity = accountBookRepository.save(accountBookEntity);
 
-    return AccountBookUpdateResponseDto.fromEntity(updatedAccountBookEntity);
+    AccountBookUpdateResponseDto responseDto = AccountBookUpdateResponseDto.fromEntity(updatedAccountBookEntity);
+    responseDto.setAssetGroup(assetEntity.getGroup().getValue());
+    responseDto.setAssetType(assetEntity.getType().getValue());
+
+    return responseDto;
   }
 
   @Transactional

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/domain/Asset.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/domain/Asset.java
@@ -2,6 +2,7 @@ package com.cozybinarybase.accountstopthestore.model.asset.domain;
 
 import com.cozybinarybase.accountstopthestore.model.asset.dto.AssetSaveRequestDto;
 import com.cozybinarybase.accountstopthestore.model.asset.dto.AssetUpdateRequestDto;
+import com.cozybinarybase.accountstopthestore.model.asset.dto.constants.AssetGroup;
 import com.cozybinarybase.accountstopthestore.model.asset.dto.constants.AssetType;
 import com.cozybinarybase.accountstopthestore.model.asset.persist.entity.AssetEntity;
 import com.cozybinarybase.accountstopthestore.model.member.persist.entity.MemberEntity;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component;
 public class Asset {
 
   private Long id;
+  private AssetGroup group;
   private AssetType type;
   private String name;
   private Long amount;
@@ -33,6 +35,7 @@ public class Asset {
   public Asset createAsset(AssetSaveRequestDto requestDto, Long memberId) {
 
     return Asset.builder()
+        .group(requestDto.getAssetGroup())
         .type(requestDto.getAssetType())
         .name(requestDto.getAssetName())
         .amount(requestDto.getAmount())
@@ -44,6 +47,9 @@ public class Asset {
   }
 
   public void update(AssetUpdateRequestDto requestDto) {
+    if (requestDto.getAssetGroup() != null) {
+      this.group = requestDto.getAssetGroup();
+    }
     if (requestDto.getAssetType() != null) {
       this.type = requestDto.getAssetType();
     }
@@ -73,6 +79,7 @@ public class Asset {
   public AssetEntity toEntity() {
     return AssetEntity.builder()
         .id(this.id)
+        .group(this.group)
         .type(this.type)
         .name(this.name)
         .amount(this.amount)
@@ -88,6 +95,7 @@ public class Asset {
   public static Asset fromEntity(AssetEntity assetEntity) {
     return Asset.builder()
         .id(assetEntity.getId())
+        .group(assetEntity.getGroup())
         .type(assetEntity.getType())
         .name(assetEntity.getName())
         .amount(assetEntity.getAmount())

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetResponseDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetResponseDto.java
@@ -1,5 +1,6 @@
 package com.cozybinarybase.accountstopthestore.model.asset.dto;
 
+import com.cozybinarybase.accountstopthestore.model.asset.dto.constants.AssetGroup;
 import com.cozybinarybase.accountstopthestore.model.asset.persist.entity.AssetEntity;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
@@ -16,6 +17,7 @@ import lombok.NoArgsConstructor;
 public class AssetResponseDto {
 
   private Long assetId;
+  private String assetGroup;
   private String assetType;
   private String assetName;
   private Long amount;
@@ -32,6 +34,7 @@ public class AssetResponseDto {
   public static AssetResponseDto fromEntity(AssetEntity assetEntity) {
     return AssetResponseDto.builder()
         .assetId(assetEntity.getId())
+        .assetGroup(assetEntity.getGroup().getValue())
         .assetType(assetEntity.getType().getValue())
         .assetName(assetEntity.getName())
         .amount(assetEntity.getAmount())

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetSaveRequestDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetSaveRequestDto.java
@@ -1,5 +1,6 @@
 package com.cozybinarybase.accountstopthestore.model.asset.dto;
 
+import com.cozybinarybase.accountstopthestore.model.asset.dto.constants.AssetGroup;
 import com.cozybinarybase.accountstopthestore.model.asset.dto.constants.AssetType;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -10,6 +11,9 @@ import lombok.Setter;
 @Setter
 @Getter
 public class AssetSaveRequestDto {
+
+  @NotNull(message = "자산 그룹을 입력해주시길 바랍니다.")
+  private AssetGroup assetGroup;
 
   @NotNull(message = "자산 유형을 입력해주시길 바랍니다.")
   private AssetType assetType;

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetSaveResponseDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetSaveResponseDto.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 public class AssetSaveResponseDto {
 
   private Long assetId;
+  private String assetGroup;
   private String assetType;
   private String assetName;
   private Integer statementDay;
@@ -23,6 +24,7 @@ public class AssetSaveResponseDto {
   public static AssetSaveResponseDto fromEntity(AssetEntity assetEntity) {
     return AssetSaveResponseDto.builder()
         .assetId(assetEntity.getId())
+        .assetGroup(assetEntity.getGroup().getValue())
         .assetType(assetEntity.getType().getValue())
         .assetName(assetEntity.getName())
         .statementDay(assetEntity.getStatementDay())

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetUpdateRequestDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.cozybinarybase.accountstopthestore.model.asset.dto;
 
+import com.cozybinarybase.accountstopthestore.model.asset.dto.constants.AssetGroup;
 import com.cozybinarybase.accountstopthestore.model.asset.dto.constants.AssetType;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
@@ -13,6 +14,7 @@ import lombok.Setter;
 @Getter
 public class AssetUpdateRequestDto {
 
+  private AssetGroup assetGroup;
   private AssetType assetType;
 
   @NotBlank(message = "자산명을 입력해주시길 바랍니다.")

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetUpdateResponseDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetUpdateResponseDto.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class AssetUpdateResponseDto {
 
+  private String assetGroup;
   private String assetType;
   private String assetName;
   private Long amount;
@@ -31,6 +32,7 @@ public class AssetUpdateResponseDto {
 
   public static AssetUpdateResponseDto fromEntity(AssetEntity assetEntity) {
     return AssetUpdateResponseDto.builder()
+        .assetGroup(assetEntity.getGroup().getValue())
         .assetType(assetEntity.getType().getValue())
         .assetName(assetEntity.getName())
         .amount(assetEntity.getAmount())

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/constants/AssetType.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/constants/AssetType.java
@@ -8,9 +8,21 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum AssetType {
 
-  MONEY("현금"),
-  BANK("은행"),
-  CARD("카드");
+  KB_KOOKMIN_BANK("국민은행"),
+  SHINHAN_BANK("신한은행"),
+  WOORI_BANK("우리은행"),
+  HANA_BANK("하나은행"),
+  IBK_BANK("기업은행"),
+  NH_NONGHYUP_BANK("농협은행"),
+  SHINHAN_CARD("신한카드"),
+  HYUNDAI_CARD("현대카드"),
+  SAMSUNG_CARD("삼성카드"),
+  KB_KOOKMIN_CARD("KB국민카드"),
+  NH_NONGHYUP_CARD("NH농협카드"),
+  WOORI_CARD("우리카드"),
+  LOTTE_CARD("롯데카드"),
+  BC_CARD("비씨카드"),
+  HANA_CARD("하나카드");
 
   private final String value;
 

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/persist/entity/AssetEntity.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/persist/entity/AssetEntity.java
@@ -1,5 +1,6 @@
 package com.cozybinarybase.accountstopthestore.model.asset.persist.entity;
 
+import com.cozybinarybase.accountstopthestore.model.asset.dto.constants.AssetGroup;
 import com.cozybinarybase.accountstopthestore.model.asset.dto.constants.AssetType;
 import com.cozybinarybase.accountstopthestore.model.member.persist.entity.MemberEntity;
 import java.time.LocalDateTime;
@@ -37,6 +38,10 @@ public class AssetEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
+
+  @Column(name = "assetGroup")
+  @Enumerated(EnumType.STRING)
+  private AssetGroup group;
 
   @Column(name = "assetType")
   @Enumerated(EnumType.STRING)

--- a/src/test/java/com/cozybinarybase/accountstopthestore/model/asset/service/AssetServiceTest.java
+++ b/src/test/java/com/cozybinarybase/accountstopthestore/model/asset/service/AssetServiceTest.java
@@ -11,6 +11,7 @@ import com.cozybinarybase.accountstopthestore.model.asset.dto.AssetSaveRequestDt
 import com.cozybinarybase.accountstopthestore.model.asset.dto.AssetSaveResponseDto;
 import com.cozybinarybase.accountstopthestore.model.asset.dto.AssetUpdateRequestDto;
 import com.cozybinarybase.accountstopthestore.model.asset.dto.AssetUpdateResponseDto;
+import com.cozybinarybase.accountstopthestore.model.asset.dto.constants.AssetGroup;
 import com.cozybinarybase.accountstopthestore.model.asset.dto.constants.AssetType;
 import com.cozybinarybase.accountstopthestore.model.asset.persist.entity.AssetEntity;
 import com.cozybinarybase.accountstopthestore.model.asset.persist.repository.AssetRepository;
@@ -22,6 +23,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -47,7 +49,7 @@ class AssetServiceTest {
   void 자산_추가_test() throws Exception {
     // given
     AssetSaveRequestDto requestDto = new AssetSaveRequestDto();
-    requestDto.setAssetType(AssetType.CARD);
+    requestDto.setAssetGroup(AssetGroup.CARD);
     requestDto.setAssetName("우리카드");
     requestDto.setAmount(100000L);
     requestDto.setStatementDay(10);
@@ -64,7 +66,8 @@ class AssetServiceTest {
 
     AssetEntity savedAsset = AssetEntity.builder()
         .id(1L)
-        .type(AssetType.CARD)
+        .group(AssetGroup.CARD)
+        .type(AssetType.WOORI_CARD)
         .name("우리카드")
         .amount(100000L)
         .statementDay(10)
@@ -73,7 +76,8 @@ class AssetServiceTest {
         .build();
 
     Asset assetDomain = Asset.builder()
-        .type(AssetType.CARD)
+        .group(AssetGroup.CARD)
+        .type(AssetType.WOORI_CARD)
         .name("우리카드")
         .amount(100000L)
         .statementDay(10)
@@ -109,7 +113,8 @@ class AssetServiceTest {
   void 자산_수정_test() throws Exception {
     // given
     AssetUpdateRequestDto requestDto = new AssetUpdateRequestDto();
-    requestDto.setAssetType(AssetType.CARD);
+    requestDto.setAssetGroup(AssetGroup.CARD);
+    requestDto.setAssetType(AssetType.WOORI_CARD);
     requestDto.setAssetName("우리카드");
     requestDto.setAmount(100000L);
     requestDto.setStatementDay(10);
@@ -128,7 +133,7 @@ class AssetServiceTest {
 
     AssetEntity savedAsset = AssetEntity.builder()
         .id(1L)
-        .type(AssetType.MONEY)
+        .group(AssetGroup.MONEY)
         .name("월급")
         .amount(200000L)
         .statementDay(1)
@@ -176,7 +181,7 @@ class AssetServiceTest {
 
     AssetEntity savedAsset = AssetEntity.builder()
         .id(1L)
-        .type(AssetType.MONEY)
+        .group(AssetGroup.MONEY)
         .name("월급")
         .amount(200000L)
         .statementDay(1)
@@ -213,7 +218,8 @@ class AssetServiceTest {
 
     assetEntityList.add(AssetEntity.builder()
         .id(1L)
-        .type(AssetType.CARD)
+        .group(AssetGroup.CARD)
+        .type(AssetType.WOORI_CARD)
         .name("우리카드")
         .amount(100000L)
         .statementDay(10)
@@ -223,7 +229,7 @@ class AssetServiceTest {
 
     assetEntityList.add(AssetEntity.builder()
         .id(1L)
-        .type(AssetType.MONEY)
+        .group(AssetGroup.MONEY)
         .name("적금")
         .amount(200000L)
         .statementDay(1)


### PR DESCRIPTION
### 변경사항
**AS-IS**
- AssetGroup(현금, 은행, 카드), AssetType(각 은행사, 카드사), AssetName(사용자 지정 표시 이름)을 사용하도록 자산, 가계부 수정했습니다.

**TO-BE**

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 
