### PR TITLE
좌표를 찾을 수 없는 주소가 입력되었을 때도 입력 가능.

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/common/service/AddressService.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/common/service/AddressService.java
@@ -40,11 +40,15 @@ public class AddressService {
 
     if (!addressInfoJson.getJSONArray("documents").isEmpty()) {
       JSONObject documentObject = addressInfoJson.getJSONArray("documents").getJSONObject(0);
-      // road_address가 존재하지 않을 경우 예외처리
-      // 커스텀 예외 작성 후 전역 예외 핸들러에서 처리
-      JSONObject roadAddressObject = documentObject.getJSONObject("road_address");
-      coordinates.put("x", roadAddressObject.getString("x"));
-      coordinates.put("y", roadAddressObject.getString("y"));
+
+      // optJSONObject를 사용하여 "road_address"가 없는 경우 null을 반환
+      JSONObject roadAddressObject = documentObject.optJSONObject("road_address");
+
+      // roadAddressObject가 null이 아닐 때만 x, y 좌표를 설정
+      if (roadAddressObject != null) {
+        coordinates.put("x", roadAddressObject.getString("x"));
+        coordinates.put("y", roadAddressObject.getString("y"));
+      }
     }
 
     return coordinates;

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/constants/AssetGroup.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/constants/AssetGroup.java
@@ -1,0 +1,20 @@
+package com.cozybinarybase.accountstopthestore.model.asset.dto.constants;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum AssetGroup {
+  MONEY("현금"),
+  BANK("은행"),
+  CARD("카드");
+
+  private final String value;
+
+  @JsonValue
+  public String toValue() {
+    return this.value;
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 좌표를 찾을 수 없는 주소가 입력되었을 때도 위, 경도를 null로 설정하여 가계부가 등록되도록 수정했습니다.
- AssetGroup Enum이 누락되어 추가하였습니다.

**TO-BE**

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 
