### PR TITLE
가계부 작성 시 자산 액수 변경.

### DIFF
--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetSaveRequestDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetSaveRequestDto.java
@@ -5,6 +5,7 @@ import com.cozybinarybase.accountstopthestore.model.asset.dto.constants.AssetTyp
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -21,7 +22,7 @@ public class AssetSaveRequestDto {
   @NotBlank(message = "자산명을 입력해주시길 바랍니다.")
   private String assetName;
 
-  @Positive(message = "양수의 값만 입력할 수 있습니다.")
+  @PositiveOrZero(message = "음수는 입력할 수 없습니다.")
   private Long amount;
 
   @Positive(message = "양수의 값만 입력할 수 있습니다.")

--- a/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetUpdateRequestDto.java
+++ b/src/main/java/com/cozybinarybase/accountstopthestore/model/asset/dto/AssetUpdateRequestDto.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import java.time.LocalDateTime;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -20,7 +21,7 @@ public class AssetUpdateRequestDto {
   @NotBlank(message = "자산명을 입력해주시길 바랍니다.")
   private String assetName;
 
-  @Positive(message = "양수의 값만 입력할 수 있습니다.")
+  @PositiveOrZero(message = "음수는 입력할 수 없습니다.")
   private Long amount;
 
   @Positive(message = "양수의 값만 입력할 수 있습니다.")


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 가계부 작성이나 변경 시 자산의 액수가 맞춰서 변하도록 작성했습니다.
- 자산의 액수는 음수가 아니면 허용하도록 수정했습니다.(0을 포함한 양수)

**TO-BE**

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 
